### PR TITLE
Mark compatible with NVDA 2026.1

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -41,7 +41,7 @@ addon_info = {
 	# Minimum NVDA version supported
 	"addon_minimumNVDAVersion": "2024.3",
 	# Last NVDA version supported/tested
-	"addon_lastTestedNVDAVersion": "2025.1",
+	"addon_lastTestedNVDAVersion": "2026.1",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!


### PR DESCRIPTION
## Summary

- Bumps `addon_lastTestedNVDAVersion` to `2026.1`
- No code changes needed; all APIs the add-on uses are still present and behave the same in 2026.1

## Test plan

- [x] Loads and runs cleanly on NVDA 2026.1 (Python 3.13, 64-bit)
- [x] NVDA+Ctrl+I opens the Convert Braille dialog
- [x] Dot input → Unicode braille / BRF / NABCC round-trips correctly
- [x] Text input → Unicode (using current input/output table) works
- [x] Clipboard and file export both work

🤖 Generated with [Claude Code](https://claude.com/claude-code)